### PR TITLE
Add drawio_disable_dev_shm_usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ conflict. This option only affects the output when the drawio app errors. See th
 [Electron docs](https://www.electronjs.org/docs/latest/api/command-line-switches#--enable-loggingfile)
 for more info.
 
+### Disable Shared Memory Usage
+- *Formal Name*: `drawio_disable_dev_shm_usage`
+- *Default Value*: `False`
+- *Possible Values*: `True` or `False`
+
+By default, Docker runs a container with a `/dev/shm` shared memory space of 64MB.
+This is typically too small for Chrome (Electron) and will cause Chrome to throw
+an error. Launching the browser with the `--disable-dev-shm-usage` flag will write
+shared memory files into `/tmp` instead of `/dev/shm`.
+
 ### No Sandbox
 - *Formal Name*: `drawio_no_sandbox`
 - *Default Value*: `False`

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -237,6 +237,7 @@ class DrawIOConverter(ImageConverter):
             "transparency", builder.config.drawio_default_transparency
         )
         disable_verbose_electron = builder.config.drawio_disable_verbose_electron
+        disable_dev_shm_usage = builder.config.drawio_disable_dev_shm_usage
         no_sandbox = builder.config.drawio_no_sandbox
 
         # Any directive options which would change the output file would go here
@@ -319,6 +320,9 @@ class DrawIOConverter(ImageConverter):
 
         if not disable_verbose_electron:
             drawio_args.append("--enable-logging")
+
+        if disable_dev_shm_usage:
+            drawio_args.append("--disable-dev-shm-usage")
 
         if no_sandbox:
             # This may be needed for docker support, and it has to be the last argument to work.
@@ -418,6 +422,9 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # noinspection PyTypeChecker
     app.add_config_value(
         "drawio_disable_verbose_electron", False, "html", ENUM(True, False)
+    )
+    app.add_config_value(
+        "drawio_disable_dev_shm_usage", False, "html", ENUM(True, False)
     )
     app.add_config_value("drawio_no_sandbox", False, "html", ENUM(True, False))
 


### PR DESCRIPTION
Fixes `WARNING:discardable_shared_memory_manager.cc(197)] Less than 64MB of free space in temporary directory for shared memory files: 40`.

This [comment on the original chromium tracker](https://bugs.chromium.org/p/chromium/issues/detail?id=736452#c65) seems to indicate there shouldn't be much of a difference in performance, and I haven't noted any thus far.